### PR TITLE
Keyboard shortcuts

### DIFF
--- a/src/windows.py
+++ b/src/windows.py
@@ -157,6 +157,7 @@ class MainWindowHandler:
         self.rotation_ref = RotationRef.CENTER
         self.current_file = None
         self.clipping_method = LineClippingMethod.COHEN_SUTHERLAND
+        self.pressed_keys = set()
 
     def log(self, msg: str):
         self.output_buffer.insert_at_cursor(f'{msg}\n')
@@ -244,6 +245,36 @@ class MainWindowHandler:
         )
         about_dialog.run()
         about_dialog.close()
+
+    def on_key_press(self, widget, event):
+        '''
+        Returns: False if event can propagate, True otherwise.
+        '''
+        DIRECTIONS = {
+            Gdk.KEY_Up: Vec2(0, -10),
+            Gdk.KEY_Down: Vec2(0, 10),
+            Gdk.KEY_Left: Vec2(10, 0),
+            Gdk.KEY_Right: Vec2(-10, 0),
+        }
+
+        self.pressed_keys |= {event.keyval}
+
+        for key in self.pressed_keys:
+            if key in DIRECTIONS:
+                self.world_window.offset(DIRECTIONS[key])
+
+        self.window.queue_draw()
+
+        return True
+
+    def on_key_release(self, widget, event):
+        '''
+        Returns: False if event can propagate, True otherwise.
+        '''
+
+        self.pressed_keys -= {event.keyval}
+
+        return False
 
     def on_button_press(self, widget, event):
         if BUTTON_EVENTS[event.button] == 'left':

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -713,7 +713,7 @@
             <child>
               <object class="GtkBox" id="right-box">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
@@ -730,17 +730,20 @@
                     <child>
                       <object class="GtkViewport" id="viewport">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
                         <child>
                           <object class="GtkDrawingArea" id="drawing_area">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="has_focus">True</property>
                             <property name="events">GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK | GDK_SCROLL_MASK</property>
                             <signal name="button-press-event" handler="on_button_press" swapped="no"/>
                             <signal name="button-release-event" handler="on_button_release" swapped="no"/>
                             <signal name="draw" handler="on_draw" swapped="no"/>
+                            <signal name="key-press-event" handler="on_key_press" swapped="no"/>
+                            <signal name="key-release-event" handler="on_key_release" swapped="no"/>
                             <signal name="motion-notify-event" handler="on_motion" swapped="no"/>
                             <signal name="scroll-event" handler="on_scroll" swapped="no"/>
                             <signal name="size-allocate" handler="on_resize" swapped="no"/>
@@ -762,12 +765,14 @@
                         <child>
                           <object class="GtkTextView" id="output">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="can_focus">False</property>
                             <property name="hscroll_policy">natural</property>
                             <property name="vscroll_policy">natural</property>
+                            <property name="editable">False</property>
                             <property name="wrap_mode">word</property>
                             <property name="left_margin">4</property>
                             <property name="buffer">outputbuffer</property>
+                            <property name="accepts_tab">False</property>
                             <property name="monospace">True</property>
                           </object>
                         </child>
@@ -788,6 +793,7 @@
                   <object class="GtkTextView" id="input">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="accepts_tab">False</property>
                     <property name="populate_all">True</property>
                     <property name="monospace">True</property>
                   </object>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -72,6 +72,7 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_new_file" swapped="no"/>
+                        <accelerator key="n" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -82,6 +83,7 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_open_file" swapped="no"/>
+                        <accelerator key="o" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -92,6 +94,7 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_save_file" swapped="no"/>
+                        <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -102,6 +105,7 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_save_file" swapped="no"/>
+                        <accelerator key="s" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -141,6 +145,7 @@
                         <property name="image">img_add</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="on_new_object" swapped="no"/>
+                        <accelerator key="a" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -151,6 +156,7 @@
                         <property name="image">img_delete</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="remove_selected_objects" swapped="no"/>
+                        <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                   </object>
@@ -175,6 +181,7 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_about" swapped="no"/>
+                        <accelerator key="F1" signal="activate"/>
                       </object>
                     </child>
                   </object>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -156,7 +156,7 @@
                         <property name="image">img_delete</property>
                         <property name="use_stock">False</property>
                         <signal name="activate" handler="remove_selected_objects" swapped="no"/>
-                        <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="Delete" signal="activate"/>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
Basicamente adiciona os atalhos da #29, com a diferença que é usado <kbd>Ctrl</kbd>+<kbd>D</kbd> para "Delete Object" (e não há um "Edit Object").